### PR TITLE
최종 발송 결과 목록 조회 API 가이드 추가

### DIFF
--- a/ko/api-guide-v1x0/contact-delivery-result.md
+++ b/ko/api-guide-v1x0/contact-delivery-result.md
@@ -148,7 +148,7 @@ X-NHN-Authorization: Bearer {accessToken}
 | contactDeliveryResults[].messageChannel           | String              | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH                                                      |
 | contactDeliveryResults[].messagePurpose           | String              | 메시지 목적                                                                                                     |
 | contactDeliveryResults[].confirmBeforeSend        | Boolean             | 승인 후 발송 사용 여부                                                                                              |
-| contactDeliveryResults[].confirmedDateTime        | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00+09:00)                                                                        |
+| contactDeliveryResults[].confirmedDateTime        | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00.000+09:00)                                                                    |
 | contactDeliveryResults[].scheduled                | Boolean             | 예약 발송 여부                                                                                                   |
 | contactDeliveryResults[].scheduledDateTime        | DateTime(ISO 86091) | 예약 발송 일시                                                                                                   |
 | contactDeliveryResults[].status                   | String              | 상태<br> 요청(REQUESTED), 요청 취소(CANCELED), 발송(SENT), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED) |
@@ -156,7 +156,7 @@ X-NHN-Authorization: Bearer {accessToken}
 | contactDeliveryResults[].resultMessage            | String              | 결과 메시지                                                                                                     |
 | contactDeliveryResults[].templateParameters       | Object              | 템플릿 파라미터                                                                                                   |
 | contactDeliveryResults[].additionalProperty       | Object              | 추가 속성, 알림톡, RCS만 제공                                                                                        |
-| contactDeliveryResults[].createdDateTime          | DateTime(ISO 86091) | 요청 일시(예: 2024-10-29T06:09:00+09:00)                                                                        |
+| contactDeliveryResults[].createdDateTime          | DateTime(ISO 86091) | 요청 일시(예: 2024-10-29T06:09:00.000+09:00)                                                                    |
 | contactDeliveryResults[].sentDateTime             | DateTime(ISO 86091) | 발송 일시, 발송 이벤트가 수집되기 전까지 값은 null                                                                            |
 | contactDeliveryResults[].deliveredDateTime        | DateTime(ISO 86091) | 수신 일시, 수신 이벤트가 수집되기 전까지 값은 null                                                                            |
 | contactDeliveryResults[].openedDateTime           | DateTime(ISO 86091) | 열람 일시, 열람 이벤트가 수집되기 전까지 값은 null, 푸시와 이메일만 제공                                                               |
@@ -323,7 +323,7 @@ X-NHN-Authorization: Bearer {accessToken}
 | contactDeliveryResults[].messageChannel           | String              | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH                             |
 | contactDeliveryResults[].messagePurpose           | String              | 메시지 목적                                                                            |
 | contactDeliveryResults[].confirmBeforeSend        | Boolean             | 승인 후 발송 사용 여부                                                                     |
-| contactDeliveryResults[].confirmedDateTime        | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00+09:00)                                               |
+| contactDeliveryResults[].confirmedDateTime        | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00.000+09:00)                                              |
 | contactDeliveryResults[].scheduled                | Boolean             | 예약 발송 여부                                                                          |
 | contactDeliveryResults[].scheduledDateTime        | DateTime(ISO 86091) | 예약 발송 일시                                                                          |
 | contactDeliveryResults[].status                   | String              | 상태<br> 요청 취소(CANCELED), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED) |
@@ -331,7 +331,7 @@ X-NHN-Authorization: Bearer {accessToken}
 | contactDeliveryResults[].resultMessage            | String              | 결과 메시지                                                                            |
 | contactDeliveryResults[].templateParameters       | Object              | 템플릿 파라미터                                                                          |
 | contactDeliveryResults[].additionalProperty       | Object              | 추가 속성, 알림톡, RCS만 제공                                                               |
-| contactDeliveryResults[].createdDateTime          | DateTime(ISO 86091) | 요청 일시(예: 2024-10-29T06:09:00+09:00)                                               |
+| contactDeliveryResults[].createdDateTime          | DateTime(ISO 86091) | 요청 일시(예: 2024-10-29T06:09:00.000+09:00)                                           |
 | contactDeliveryResults[].sentDateTime             | DateTime(ISO 86091) | 발송 일시, 발송 이벤트가 수집되기 전까지 값은 null                                                   |
 | contactDeliveryResults[].deliveredDateTime        | DateTime(ISO 86091) | 수신 일시, 수신 이벤트가 수집되기 전까지 값은 null                                                   |
 | contactDeliveryResults[].openedDateTime           | DateTime(ISO 86091) | 열람 일시, 열람 이벤트가 수집되기 전까지 값은 null, 푸시와 이메일만 제공                                      |

--- a/ko/api-guide-v1x0/contact-delivery-result.md
+++ b/ko/api-guide-v1x0/contact-delivery-result.md
@@ -214,3 +214,176 @@ curl -X GET "${ENDPOINT}/message/v1.0/contact-delivery-results" \
 
 </details>
 
+### 최종 발송 결과 목록 조회
+
+발송 요청된 메시지 중 최종 발송 상태인 결과만 수신자의 연락처 단위로 조회합니다.
+
+최종 발송 상태에는 요청 취소(CANCELED), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED)가 있습니다.
+
+**요청**
+
+```
+GET /message/v1.0/final-contact-delivery-results
+X-NC-APP-KEY: {appKey}
+X-NHN-Authorization: Bearer {accessToken}
+```
+
+**요청 파라미터**
+
+| 이름                  | 구분 | 타입 | 필수 | 설명                                                   |
+|---------------------| --- | --- |----|------------------------------------------------------|
+| appKey              | Header | String | Y  | 앱키                                                   |
+| accessToken         | Header | String | Y  | 인증 토큰                                                |
+| updatedDateTimeFrom | Query | DateTime(ISO 8601) | Y  | 결과 업데이트 일시 시작 범위                                     |
+| updatedDateTimeTo   | Query | DateTime(ISO 8601) | Y  | 결과 업데이트 일시 종료 범위                                     |
+| messageId           | Query | String | N  | 메시지 아이디                                              |
+| templateId          | Query | String | N  | 템플릿 아이디                                              |
+| flowId              | Query | String | N  | 플로우 아이디                                              |
+| statsKeyId          | Query | String | N  | 통계 키 아이디                                             |
+| sender              | Query | String | N  | 발신자                                                  |
+| contact             | Query | String | N  | 연락처                                                  |
+| messageChannel      | Query | String | N  | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH |
+| messagePurpose      | Query | String | N  | 메시지 목적                                               |
+| scheduled           | Query | Boolean | N  | 예약 발송 여부                                             |
+| confirmBeforeSend   | Query | Boolean | N  | 발송 전 확인 여부                                           |
+| limit               | Query | Integer | N  | 조회 개수                                                |
+| offset              | Query | Integer | N  | 조회 시작 위치                                             |
+
+* **updatedDateTimeFrom**과 **updatedDateTimeTo**의 최대 조회 기간은 7일입니다.
+
+**요청 본문**
+
+<!--요청 본문을 요구하지 않는다면 "이 API는 요청 본문을 요구하지 않습니다"로 입력합니다.-->
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+<!--요청 본문의 필드를 설명합니다.-->
+
+**응답 본문**
+
+<!--응답 본문을 반환하지 않는다면 "이 API는 응답 본문을 반환하지 않습니다"로 입력합니다.-->
+
+
+```json
+{
+  "header": {
+    "isSuccessful": true,
+    "resultCode": 0,
+    "resultMessage": "SUCCESS"
+  },
+  "contactDeliveryResults": [
+    {
+      "messageId": "메시지의 아이디",
+      "recipientIndex": 0,
+      "contactIndex": 0,
+      "contactType": "PHONE_NUMBER",
+      "contact": "01012345678",
+      "sender": {
+        "senderKey": "발신_키",
+        "senderProfileId": "@nhnCloud",
+        "senderProfileType": "GROUP",
+        "senderPhoneNumber": "01012341234",
+        "senderMailAddress": "abcde@nhn.com",
+        "brandId": "AR.lj0eOjEI7Y",
+        "chatbotId": "01012341234"
+      },
+      "templateId": "템플릿의 아이디",
+      "flowId": "플로우의 아이디",
+      "statsKeyId": "통계 키의 아이디",
+      "messageChannel": "SMS",
+      "messagePurpose": "NORMAL",
+      "confirmBeforeSend": false,
+      "confirmedDateTime": "2023-01-01T00:00:00Z",
+      "scheduled": false,
+      "scheduledDateTime": "2024-10-26T07:52:12.728Z",
+      "status": "DELIVERED",
+      "resultCode": "5.0.0",
+      "resultMessage": "Success",
+      "templateParameters": {
+        "key1": "value1",
+        "key2": "value2"
+      },
+      "additionalProperty": {
+        
+      },
+      "createdDateTime": "2023-01-01T00:00:00Z",
+      "sentDateTime": "2023-01-01T00:00:00Z",
+      "deliveredDateTime": "2023-01-01T00:00:00Z",
+      "openedDateTime": "2023-01-01T00:00:00Z",
+      "updatedDateTime": "2023-01-01T00:00:00Z"
+    }
+  ],
+  "totalCount": 1
+}
+```
+
+<!--응답 본문의 필드를 설명합니다.-->
+
+| 이름 | 타입 | 설명                                                                                |
+| --- | --- |-----------------------------------------------------------------------------------|
+| header.isSuccessful | Boolean | API 요청 성공 여부                                                                      |
+| header.resultCode | Integer | 결과 코드                                                                             |
+| header.resultMessage | String | 결과 메시지                                                                            |
+| contactDeliveryResults | Object Array | 연락처별 수신 결과 목록                                                                     |
+| contactDeliveryResults[].messageId | String| 메시지의 아이디                                                                          |
+| contactDeliveryResults[].recipientIndex | Number| 수신자 인덱스                                                                           |
+| contactDeliveryResults[].contactIndex | Number| 연락처 인덱스                                                                           |
+| contactDeliveryResults[].contactType | String| 연락처 타입                                                                            |
+| contactDeliveryResults[].contact | String| 연락처                                                                               |
+| contactDeliveryResults[].sender | Object| 발신자                                                                               |
+| contactDeliveryResults[].sender.senderKey | String| 발신 프로필 발신 키, 알림톡과 친구톡만 표시                                                         |
+| contactDeliveryResults[].sender.senderProfileId | String| 발신 프로필 아이디, 알림톡과 친구톡만 표시                                                          |
+| contactDeliveryResults[].sender.senderProfileType | String| 발신 프로필 타입, 알림톡과 친구톡만 표시                                                           |
+| contactDeliveryResults[].sender.senderPhoneNumber | String| 발신자 전화번호, SMS만 표시                                                                 |
+| contactDeliveryResults[].sender.senderMailAddress | String| 발신자 이메일 주소, 이메일만 표시                                                               |
+| contactDeliveryResults[].sender.brandId | String| 브랜드 아이디, RCS만 표시                                                                  |
+| contactDeliveryResults[].sender.chatbotId | String| 대화방 아이디, RCS만 표시                                                                  |
+| contactDeliveryResults[].templateId | String| 템플릿의 아이디, 템플릿 메시지만 표시                                                             |
+| contactDeliveryResults[].flowId | String| 플로우의 아이디, 템플릿 메시지만 표시                                                             |
+| contactDeliveryResults[].statsKeyId | String| 통계 키의 아이디                                                                         |
+| contactDeliveryResults[].messageChannel | String| 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH                             |
+| contactDeliveryResults[].messagePurpose | String| 메시지 목적                                                                            |
+| contactDeliveryResults[].confirmBeforeSend | Boolean | 승인 후 발송 사용 여부                                                                     |
+| contactDeliveryResults[].confirmedDateTime | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00+09:00)                                               |
+| contactDeliveryResults[].scheduled | Boolean | 예약 발송 여부                                                                          |
+| contactDeliveryResults[].scheduledDateTime | DateTime(ISO 86091) | 예약 발송 일시                                                                          |
+| contactDeliveryResults[].status | String| 상태<br> 요청 취소(CANCELED), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED) |
+| contactDeliveryResults[].resultCode | String| 결과 코드                                                                             |
+| contactDeliveryResults[].resultMessage | String| 결과 메시지                                                                            |
+| contactDeliveryResults[].templateParameters | Object| 템플릿 파라미터                                                                          |
+| contactDeliveryResults[].additionalProperty | Object| 추가 속성, 알림톡, RCS만 제공                                                               |
+| contactDeliveryResults[].createdDateTime | DateTime(ISO 86091) | 생성 일시(예: 2024-10-29T06:09:00+09:00)                                               |
+| contactDeliveryResults[].sentDateTime | DateTime(ISO 86091) | 발송 일시, 발송 이벤트가 수집되기 전까지 값은 null                                                   |
+| contactDeliveryResults[].deliveredDateTime | DateTime(ISO 86091) | 수신 일시, 수신 이벤트가 수집되기 전까지 값은 null                                                   |
+| contactDeliveryResults[].openedDateTime | DateTime(ISO 86091) | 열람 일시, 열람 이벤트가 수집되기 전까지 값은 null, 푸시와 이메일만 제공                                      |
+| contactDeliveryResults[].updatedDateTime | DateTime(ISO 86091) | 마지막 업데이트 일시                                                                       |
+| totalCount | Number| 전체 개수                                                                             |
+
+
+
+**요청 예시**
+
+<details>
+  <summary><strong>IntelliJ HTTP</strong></summary>
+
+```http
+POST {{endpoint}}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={결과 업데이트 일시 시작 범위}&updatedDateTimeTo={결과 업데이트 일시 종료 범위}&limit=10&offset=0
+Content-Type: application/json
+X-NC-APP-KEY: {{appKey}}
+X-NHN-Authorization: {{authorizationToken}}
+```
+
+</details>
+
+<details>
+  <summary><strong>cURL</strong></summary>
+
+```curl
+curl -X GET "${ENDPOINT}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={결과 업데이트 일시 시작 범위}&updatedDateTimeTo={결과 업데이트 일시 종료 범위}&limit=10&offset=0" \
+     -H "Content-Type: application/json" \
+     -H "X-NC-APP-KEY: ${APP_KEY}" \
+     -H "X-NHN-Authorization: ${ACCESS_TOKEN}"
+```
+
+</details>
+

--- a/ko/api-guide-v1x0/contact-delivery-result.md
+++ b/ko/api-guide-v1x0/contact-delivery-result.md
@@ -9,9 +9,11 @@
 
 <span id="read-contact-delivery-results"></span>
 
-### 연락처별 수신 결과 목록 조회
+### 연락처별 발송 결과 목록 조회
 
 발송 요청된 메시지의 발송과 수신 결과를 수신자의 연락처 단위로 조회합니다.
+
+발송 요청 일시를 기준으로 조회합니다.
 
 예를 들어, 이메일과 전화번호를 가진 수신자 10명에게 이메일, SMS 템플릿으로 구성된 플로우 메시지 2개를 발송하는 경우, 연락처별 수신 결과 목록을 조회하면 40개의 항목이 조회됩니다. (연락처 2개 X 수신자 10명 X 플로우 메시지 2개 = 연락처 별 수신 결과 40개)
 다양한 검색 조건으로 연락처 별 수신 결과를 조회할 수 있습니다.
@@ -32,25 +34,25 @@ X-NHN-Authorization: Bearer {accessToken}
 
 **요청 파라미터**
 
-| 이름 | 구분 | 타입 | 필수 | 설명 |
-| --- | --- | --- |----| --- |
-| appKey | Header | String | Y  | 앱키 |
-| accessToken | Header | String | Y  | 인증 토큰 |
-| createdDateTimeFrom | Query | DateTime(ISO 8601) | Y  | 생성 일시 시작 범위 |
-| createdDateTimeTo | Query | DateTime(ISO 8601) | Y  | 생성 일시 종료 범위 |
-| messageId | Query | String | N  | 메시지 아이디 |
-| templateId | Query | String | N  | 템플릿 아이디 |
-| flowId | Query | String | N  | 플로우 아이디 |
-| statsKeyId | Query | String | N  | 통계 키 아이디 |
-| sender | Query | String | N  | 발신자 |
-| contact | Query | String | N  | 연락처 |
-| messageChannel | Query | String | N  | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH |
-| messagePurpose | Query | String | N  | 메시지 목적 |
-| status | Query | String | N  | 상태 |
-| scheduled | Query | Boolean | N  | 예약 발송 여부 |
-| confirmBeforeSend | Query | Boolean | N  | 발송 전 확인 여부 |
-| limit | Query | Integer | N  | 조회 개수 |
-| offset | Query | Integer | N  | 조회 시작 위치 |
+| 이름                  | 구분     | 타입                 | 필수 | 설명                                                    |
+|---------------------|--------|--------------------|----|-------------------------------------------------------|
+| appKey              | Header | String             | Y  | 앱키                                                    |
+| accessToken         | Header | String             | Y  | 인증 토큰                                                 |
+| createdDateTimeFrom | Query  | DateTime(ISO 8601) | Y  | 요청 일시 시작 범위                                           |
+| createdDateTimeTo   | Query  | DateTime(ISO 8601) | Y  | 요청 일시 종료 범위                                           |
+| messageId           | Query  | String             | N  | 메시지 아이디                                               |
+| templateId          | Query  | String             | N  | 템플릿 아이디                                               |
+| flowId              | Query  | String             | N  | 플로우 아이디                                               |
+| statsKeyId          | Query  | String             | N  | 통계 키 아이디                                              |
+| sender              | Query  | String             | N  | 발신자                                                   |
+| contact             | Query  | String             | N  | 연락처                                                   |
+| messageChannel      | Query  | String             | N  | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH |
+| messagePurpose      | Query  | String             | N  | 메시지 목적                                                |
+| status              | Query  | String             | N  | 상태                                                    |
+| scheduled           | Query  | Boolean            | N  | 예약 발송 여부                                              |
+| confirmBeforeSend   | Query  | Boolean            | N  | 발송 전 확인 여부                                            |
+| limit               | Query  | Integer            | N  | 조회 개수                                                 |
+| offset              | Query  | Integer            | N  | 조회 시작 위치                                              |
 
 * **createdDateTimeFrom**과 **createdDateTimeTo**의 최대 조회 기간은 7일입니다.
 
@@ -65,7 +67,6 @@ X-NHN-Authorization: Bearer {accessToken}
 **응답 본문**
 
 <!--응답 본문을 반환하지 않는다면 "이 API는 응답 본문을 반환하지 않습니다"로 입력합니다.-->
-
 
 ```json
 {
@@ -96,9 +97,9 @@ X-NHN-Authorization: Bearer {accessToken}
       "messageChannel": "SMS",
       "messagePurpose": "NORMAL",
       "confirmBeforeSend": false,
-      "confirmedDateTime": "2023-01-01T00:00:00Z",
+      "confirmedDateTime": "2023-01-01T00:00:00.000+09:00",
       "scheduled": false,
-      "scheduledDateTime": "2024-10-26T07:52:12.728Z",
+      "scheduledDateTime": "2024-10-26T07:52:12.000+09:00",
       "status": "REQUESTED",
       "resultCode": "5.0.0",
       "resultMessage": "Success",
@@ -109,60 +110,58 @@ X-NHN-Authorization: Bearer {accessToken}
       "additionalProperty": {
         
       },
-      "createdDateTime": "2023-01-01T00:00:00Z",
-      "sentDateTime": "2023-01-01T00:00:00Z",
-      "deliveredDateTime": "2023-01-01T00:00:00Z",
-      "openedDateTime": "2023-01-01T00:00:00Z",
-      "updatedDateTime": "2023-01-01T00:00:00Z"
+      "createdDateTime": "2023-01-01T00:00:00.000+09:00",
+      "sentDateTime": "2023-01-01T00:00:00.000+09:00",
+      "deliveredDateTime": "2023-01-01T00:00:00.000+09:00",
+      "openedDateTime": "2023-01-01T00:00:00.000+09:00",
+      "updatedDateTime": "2023-01-01T00:00:00.000+09:00"
     }
   ],
   "totalCount": 1
 }
 ```
 
-
-
 <!--응답 본문의 필드를 설명합니다.-->
 
-| 이름 | 타입 | 설명 |
-| --- | --- | --- |
-| header.isSuccessful | Boolean | API 요청 성공 여부 |
-| header.resultCode | Integer | 결과 코드 |
-| header.resultMessage | String | 결과 메시지 |
-| contactDeliveryResults | Object Array | 연락처별 수신 결과 목록 |
-| contactDeliveryResults[].messageId | String| 메시지의 아이디 |
-| contactDeliveryResults[].recipientIndex | Number| 수신자 인덱스|
-| contactDeliveryResults[].contactIndex | Number| 연락처 인덱스|
-| contactDeliveryResults[].contactType | String| 연락처 타입 |
-| contactDeliveryResults[].contact | String| 연락처|
-| contactDeliveryResults[].sender | Object| 발신자|
-| contactDeliveryResults[].sender.senderKey | String| 발신 프로필 발신 키, 알림톡과 친구톡만 표시|
-| contactDeliveryResults[].sender.senderProfileId | String| 발신 프로필 아이디, 알림톡과 친구톡만 표시 |
-| contactDeliveryResults[].sender.senderProfileType | String| 발신 프로필 타입, 알림톡과 친구톡만 표시|
-| contactDeliveryResults[].sender.senderPhoneNumber | String| 발신자 전화번호, SMS만 표시|
-| contactDeliveryResults[].sender.senderMailAddress | String| 발신자 이메일 주소, 이메일만 표시|
-| contactDeliveryResults[].sender.brandId | String| 브랜드 아이디, RCS만 표시 |
-| contactDeliveryResults[].sender.chatbotId | String| 대화방 아이디, RCS만 표시 |
-| contactDeliveryResults[].templateId | String| 템플릿의 아이디, 템플릿 메시지만 표시|
-| contactDeliveryResults[].flowId | String| 플로우의 아이디, 템플릿 메시지만 표시|
-| contactDeliveryResults[].statsKeyId | String| 통계 키의 아이디|
-| contactDeliveryResults[].messageChannel | String| 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH |
-| contactDeliveryResults[].messagePurpose | String| 메시지 목적 |
-| contactDeliveryResults[].confirmBeforeSend | Boolean | 승인 후 발송 사용 여부|
-| contactDeliveryResults[].confirmedDateTime | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00+09:00)|
-| contactDeliveryResults[].scheduled | Boolean | 예약 발송 여부 |
-| contactDeliveryResults[].scheduledDateTime | DateTime(ISO 86091) | 예약 발송 일시 |
-| contactDeliveryResults[].status | String| 상태<br> 요청(REQUESTED), 요청 취소(CANCELED), 발송(SENT), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED)  |
-| contactDeliveryResults[].resultCode | String| 결과 코드|
-| contactDeliveryResults[].resultMessage | String| 결과 메시지 |
-| contactDeliveryResults[].templateParameters | Object| 템플릿 파라미터 |
-| contactDeliveryResults[].additionalProperty | Object| 추가 속성, 알림톡, RCS만 제공|
-| contactDeliveryResults[].createdDateTime | DateTime(ISO 86091) | 생성 일시(예: 2024-10-29T06:09:00+09:00)|
-| contactDeliveryResults[].sentDateTime | DateTime(ISO 86091) | 발송 일시, 발송 이벤트가 수집되기 전까지 값은 null|
-| contactDeliveryResults[].deliveredDateTime | DateTime(ISO 86091) | 수신 일시, 수신 이벤트가 수집되기 전까지 값은 null|
-| contactDeliveryResults[].openedDateTime | DateTime(ISO 86091) | 열람 일시, 열람 이벤트가 수집되기 전까지 값은 null, 푸시와 이메일만 제공 |
-| contactDeliveryResults[].updatedDateTime | DateTime(ISO 86091) | 마지막 업데이트 일시|
-| totalCount | Number| 전체 개수|
+| 이름                                                | 타입                  | 설명                                                                                                         |
+|---------------------------------------------------|---------------------|------------------------------------------------------------------------------------------------------------|
+| header.isSuccessful                               | Boolean             | API 요청 성공 여부                                                                                               |
+| header.resultCode                                 | Integer             | 결과 코드                                                                                                      |
+| header.resultMessage                              | String              | 결과 메시지                                                                                                     |
+| contactDeliveryResults                            | Object Array        | 연락처별 수신 결과 목록                                                                                              |
+| contactDeliveryResults[].messageId                | String              | 메시지의 아이디                                                                                                   |
+| contactDeliveryResults[].recipientIndex           | Number              | 수신자 인덱스                                                                                                    |
+| contactDeliveryResults[].contactIndex             | Number              | 연락처 인덱스                                                                                                    |
+| contactDeliveryResults[].contactType              | String              | 연락처 타입                                                                                                     |
+| contactDeliveryResults[].contact                  | String              | 연락처                                                                                                        |
+| contactDeliveryResults[].sender                   | Object              | 발신자                                                                                                        |
+| contactDeliveryResults[].sender.senderKey         | String              | 발신 프로필 발신 키, 알림톡과 친구톡만 표시                                                                                  |
+| contactDeliveryResults[].sender.senderProfileId   | String              | 발신 프로필 아이디, 알림톡과 친구톡만 표시                                                                                   |
+| contactDeliveryResults[].sender.senderProfileType | String              | 발신 프로필 타입, 알림톡과 친구톡만 표시                                                                                    |
+| contactDeliveryResults[].sender.senderPhoneNumber | String              | 발신자 전화번호, SMS만 표시                                                                                          |
+| contactDeliveryResults[].sender.senderMailAddress | String              | 발신자 이메일 주소, 이메일만 표시                                                                                        |
+| contactDeliveryResults[].sender.brandId           | String              | 브랜드 아이디, RCS만 표시                                                                                           |
+| contactDeliveryResults[].sender.chatbotId         | String              | 대화방 아이디, RCS만 표시                                                                                           |
+| contactDeliveryResults[].templateId               | String              | 템플릿의 아이디, 템플릿 메시지만 표시                                                                                      |
+| contactDeliveryResults[].flowId                   | String              | 플로우의 아이디, 템플릿 메시지만 표시                                                                                      |
+| contactDeliveryResults[].statsKeyId               | String              | 통계 키의 아이디                                                                                                  |
+| contactDeliveryResults[].messageChannel           | String              | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH                                                      |
+| contactDeliveryResults[].messagePurpose           | String              | 메시지 목적                                                                                                     |
+| contactDeliveryResults[].confirmBeforeSend        | Boolean             | 승인 후 발송 사용 여부                                                                                              |
+| contactDeliveryResults[].confirmedDateTime        | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00+09:00)                                                                        |
+| contactDeliveryResults[].scheduled                | Boolean             | 예약 발송 여부                                                                                                   |
+| contactDeliveryResults[].scheduledDateTime        | DateTime(ISO 86091) | 예약 발송 일시                                                                                                   |
+| contactDeliveryResults[].status                   | String              | 상태<br> 요청(REQUESTED), 요청 취소(CANCELED), 발송(SENT), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED) |
+| contactDeliveryResults[].resultCode               | String              | 결과 코드                                                                                                      |
+| contactDeliveryResults[].resultMessage            | String              | 결과 메시지                                                                                                     |
+| contactDeliveryResults[].templateParameters       | Object              | 템플릿 파라미터                                                                                                   |
+| contactDeliveryResults[].additionalProperty       | Object              | 추가 속성, 알림톡, RCS만 제공                                                                                        |
+| contactDeliveryResults[].createdDateTime          | DateTime(ISO 86091) | 요청 일시(예: 2024-10-29T06:09:00+09:00)                                                                        |
+| contactDeliveryResults[].sentDateTime             | DateTime(ISO 86091) | 발송 일시, 발송 이벤트가 수집되기 전까지 값은 null                                                                            |
+| contactDeliveryResults[].deliveredDateTime        | DateTime(ISO 86091) | 수신 일시, 수신 이벤트가 수집되기 전까지 값은 null                                                                            |
+| contactDeliveryResults[].openedDateTime           | DateTime(ISO 86091) | 열람 일시, 열람 이벤트가 수집되기 전까지 값은 null, 푸시와 이메일만 제공                                                               |
+| contactDeliveryResults[].updatedDateTime          | DateTime(ISO 86091) | 마지막 업데이트 일시                                                                                                |
+| totalCount                                        | Number              | 전체 개수                                                                                                      |
 
 
 
@@ -172,32 +171,10 @@ X-NHN-Authorization: Bearer {accessToken}
   <summary><strong>IntelliJ HTTP</strong></summary>
 
 ```http
-### 전문 메시지 발송
-POST {{endpoint}}/message/v1.0/contact-delivery-results
+GET {{endpoint}}/message/v1.0/contact-delivery-results?createdDateTimeFrom={요청 일시 시작 범위}&createdDateTimeTo={요청 일시 종료 범위}&limit=10&offset=0
 Content-Type: application/json
 X-NC-APP-KEY: {{appKey}}
 X-NHN-Authorization: {{authorizationToken}}
-
-{
-  "confirmBeforeSend": false,
-  "sender": {
-    "senderPhoneNumber": "01012341234"
-  },
-  "recipients": [
-    {
-      "contacts": [
-        {
-          "contactType": "PHONE_NUMBER",
-          "contact": "01012345678"
-        }
-      ]
-    }
-  ],
-  "content": {
-    "messageType": "SMS",
-    "body": "안녕하세요. NHN Cloud의 신규 상품 Notification Hub가 출시 되었습니다."
-  }
-}
 ```
 
 </details>
@@ -206,7 +183,7 @@ X-NHN-Authorization: {{authorizationToken}}
   <summary><strong>cURL</strong></summary>
 
 ```curl
-curl -X GET "${ENDPOINT}/message/v1.0/contact-delivery-results" \
+curl -X GET "${ENDPOINT}/message/v1.0/contact-delivery-results?createdDateTimeFrom={요청 일시 시작 범위}&createdDateTimeTo={요청 일시 종료 범위}&limit=10&offset=0" \
      -H "Content-Type: application/json" \
      -H "X-NC-APP-KEY: ${APP_KEY}" \
      -H "X-NHN-Authorization: ${ACCESS_TOKEN}"
@@ -214,9 +191,11 @@ curl -X GET "${ENDPOINT}/message/v1.0/contact-delivery-results" \
 
 </details>
 
-### 최종 발송 결과 목록 조회
+### 연락처별 최종 발송 결과 목록 조회
 
 발송 요청된 메시지 중 최종 발송 상태인 결과만 수신자의 연락처 단위로 조회합니다.
+
+결과 업데이트 일시를 기준으로 조회합니다.
 
 최종 발송 상태에는 요청 취소(CANCELED), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED)가 있습니다.
 
@@ -230,24 +209,24 @@ X-NHN-Authorization: Bearer {accessToken}
 
 **요청 파라미터**
 
-| 이름                  | 구분 | 타입 | 필수 | 설명                                                   |
-|---------------------| --- | --- |----|------------------------------------------------------|
-| appKey              | Header | String | Y  | 앱키                                                   |
-| accessToken         | Header | String | Y  | 인증 토큰                                                |
-| updatedDateTimeFrom | Query | DateTime(ISO 8601) | Y  | 결과 업데이트 일시 시작 범위                                     |
-| updatedDateTimeTo   | Query | DateTime(ISO 8601) | Y  | 결과 업데이트 일시 종료 범위                                     |
-| messageId           | Query | String | N  | 메시지 아이디                                              |
-| templateId          | Query | String | N  | 템플릿 아이디                                              |
-| flowId              | Query | String | N  | 플로우 아이디                                              |
-| statsKeyId          | Query | String | N  | 통계 키 아이디                                             |
-| sender              | Query | String | N  | 발신자                                                  |
-| contact             | Query | String | N  | 연락처                                                  |
-| messageChannel      | Query | String | N  | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH |
-| messagePurpose      | Query | String | N  | 메시지 목적                                               |
-| scheduled           | Query | Boolean | N  | 예약 발송 여부                                             |
-| confirmBeforeSend   | Query | Boolean | N  | 발송 전 확인 여부                                           |
-| limit               | Query | Integer | N  | 조회 개수                                                |
-| offset              | Query | Integer | N  | 조회 시작 위치                                             |
+| 이름                  | 구분     | 타입                 | 필수 | 설명                                                    |
+|---------------------|--------|--------------------|----|-------------------------------------------------------|
+| appKey              | Header | String             | Y  | 앱키                                                    |
+| accessToken         | Header | String             | Y  | 인증 토큰                                                 |
+| updatedDateTimeFrom | Query  | DateTime(ISO 8601) | Y  | 업데이트 일시 시작 범위                                         |
+| updatedDateTimeTo   | Query  | DateTime(ISO 8601) | Y  | 업데이트 일시 종료 범위                                         |
+| messageId           | Query  | String             | N  | 메시지 아이디                                               |
+| templateId          | Query  | String             | N  | 템플릿 아이디                                               |
+| flowId              | Query  | String             | N  | 플로우 아이디                                               |
+| statsKeyId          | Query  | String             | N  | 통계 키 아이디                                              |
+| sender              | Query  | String             | N  | 발신자                                                   |
+| contact             | Query  | String             | N  | 연락처                                                   |
+| messageChannel      | Query  | String             | N  | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH |
+| messagePurpose      | Query  | String             | N  | 메시지 목적                                                |
+| scheduled           | Query  | Boolean            | N  | 예약 발송 여부                                              |
+| confirmBeforeSend   | Query  | Boolean            | N  | 발송 전 확인 여부                                            |
+| limit               | Query  | Integer            | N  | 조회 개수                                                 |
+| offset              | Query  | Integer            | N  | 조회 시작 위치                                              |
 
 * **updatedDateTimeFrom**과 **updatedDateTimeTo**의 최대 조회 기간은 7일입니다.
 
@@ -293,9 +272,9 @@ X-NHN-Authorization: Bearer {accessToken}
       "messageChannel": "SMS",
       "messagePurpose": "NORMAL",
       "confirmBeforeSend": false,
-      "confirmedDateTime": "2023-01-01T00:00:00Z",
+      "confirmedDateTime": "2023-01-01T00:00:00.000+09:00",
       "scheduled": false,
-      "scheduledDateTime": "2024-10-26T07:52:12.728Z",
+      "scheduledDateTime": "2024-10-26T07:52:12.000+09:00",
       "status": "DELIVERED",
       "resultCode": "5.0.0",
       "resultMessage": "Success",
@@ -306,11 +285,11 @@ X-NHN-Authorization: Bearer {accessToken}
       "additionalProperty": {
         
       },
-      "createdDateTime": "2023-01-01T00:00:00Z",
-      "sentDateTime": "2023-01-01T00:00:00Z",
-      "deliveredDateTime": "2023-01-01T00:00:00Z",
-      "openedDateTime": "2023-01-01T00:00:00Z",
-      "updatedDateTime": "2023-01-01T00:00:00Z"
+      "createdDateTime": "2023-01-01T00:00:00.000+09:00",
+      "sentDateTime": "2023-01-01T00:00:00.000+09:00",
+      "deliveredDateTime": "2023-01-01T00:00:00.000+09:00",
+      "openedDateTime": "2023-01-01T00:00:00.000+09:00",
+      "updatedDateTime": "2023-01-01T00:00:00.000+09:00"
     }
   ],
   "totalCount": 1
@@ -319,45 +298,45 @@ X-NHN-Authorization: Bearer {accessToken}
 
 <!--응답 본문의 필드를 설명합니다.-->
 
-| 이름 | 타입 | 설명                                                                                |
-| --- | --- |-----------------------------------------------------------------------------------|
-| header.isSuccessful | Boolean | API 요청 성공 여부                                                                      |
-| header.resultCode | Integer | 결과 코드                                                                             |
-| header.resultMessage | String | 결과 메시지                                                                            |
-| contactDeliveryResults | Object Array | 연락처별 수신 결과 목록                                                                     |
-| contactDeliveryResults[].messageId | String| 메시지의 아이디                                                                          |
-| contactDeliveryResults[].recipientIndex | Number| 수신자 인덱스                                                                           |
-| contactDeliveryResults[].contactIndex | Number| 연락처 인덱스                                                                           |
-| contactDeliveryResults[].contactType | String| 연락처 타입                                                                            |
-| contactDeliveryResults[].contact | String| 연락처                                                                               |
-| contactDeliveryResults[].sender | Object| 발신자                                                                               |
-| contactDeliveryResults[].sender.senderKey | String| 발신 프로필 발신 키, 알림톡과 친구톡만 표시                                                         |
-| contactDeliveryResults[].sender.senderProfileId | String| 발신 프로필 아이디, 알림톡과 친구톡만 표시                                                          |
-| contactDeliveryResults[].sender.senderProfileType | String| 발신 프로필 타입, 알림톡과 친구톡만 표시                                                           |
-| contactDeliveryResults[].sender.senderPhoneNumber | String| 발신자 전화번호, SMS만 표시                                                                 |
-| contactDeliveryResults[].sender.senderMailAddress | String| 발신자 이메일 주소, 이메일만 표시                                                               |
-| contactDeliveryResults[].sender.brandId | String| 브랜드 아이디, RCS만 표시                                                                  |
-| contactDeliveryResults[].sender.chatbotId | String| 대화방 아이디, RCS만 표시                                                                  |
-| contactDeliveryResults[].templateId | String| 템플릿의 아이디, 템플릿 메시지만 표시                                                             |
-| contactDeliveryResults[].flowId | String| 플로우의 아이디, 템플릿 메시지만 표시                                                             |
-| contactDeliveryResults[].statsKeyId | String| 통계 키의 아이디                                                                         |
-| contactDeliveryResults[].messageChannel | String| 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH                             |
-| contactDeliveryResults[].messagePurpose | String| 메시지 목적                                                                            |
-| contactDeliveryResults[].confirmBeforeSend | Boolean | 승인 후 발송 사용 여부                                                                     |
-| contactDeliveryResults[].confirmedDateTime | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00+09:00)                                               |
-| contactDeliveryResults[].scheduled | Boolean | 예약 발송 여부                                                                          |
-| contactDeliveryResults[].scheduledDateTime | DateTime(ISO 86091) | 예약 발송 일시                                                                          |
-| contactDeliveryResults[].status | String| 상태<br> 요청 취소(CANCELED), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED) |
-| contactDeliveryResults[].resultCode | String| 결과 코드                                                                             |
-| contactDeliveryResults[].resultMessage | String| 결과 메시지                                                                            |
-| contactDeliveryResults[].templateParameters | Object| 템플릿 파라미터                                                                          |
-| contactDeliveryResults[].additionalProperty | Object| 추가 속성, 알림톡, RCS만 제공                                                               |
-| contactDeliveryResults[].createdDateTime | DateTime(ISO 86091) | 생성 일시(예: 2024-10-29T06:09:00+09:00)                                               |
-| contactDeliveryResults[].sentDateTime | DateTime(ISO 86091) | 발송 일시, 발송 이벤트가 수집되기 전까지 값은 null                                                   |
-| contactDeliveryResults[].deliveredDateTime | DateTime(ISO 86091) | 수신 일시, 수신 이벤트가 수집되기 전까지 값은 null                                                   |
-| contactDeliveryResults[].openedDateTime | DateTime(ISO 86091) | 열람 일시, 열람 이벤트가 수집되기 전까지 값은 null, 푸시와 이메일만 제공                                      |
-| contactDeliveryResults[].updatedDateTime | DateTime(ISO 86091) | 마지막 업데이트 일시                                                                       |
-| totalCount | Number| 전체 개수                                                                             |
+| 이름                                                | 타입                  | 설명                                                                                |
+|---------------------------------------------------|---------------------|-----------------------------------------------------------------------------------|
+| header.isSuccessful                               | Boolean             | API 요청 성공 여부                                                                      |
+| header.resultCode                                 | Integer             | 결과 코드                                                                             |
+| header.resultMessage                              | String              | 결과 메시지                                                                            |
+| contactDeliveryResults                            | Object Array        | 연락처별 수신 결과 목록                                                                     |
+| contactDeliveryResults[].messageId                | String              | 메시지의 아이디                                                                          |
+| contactDeliveryResults[].recipientIndex           | Number              | 수신자 인덱스                                                                           |
+| contactDeliveryResults[].contactIndex             | Number              | 연락처 인덱스                                                                           |
+| contactDeliveryResults[].contactType              | String              | 연락처 타입                                                                            |
+| contactDeliveryResults[].contact                  | String              | 연락처                                                                               |
+| contactDeliveryResults[].sender                   | Object              | 발신자                                                                               |
+| contactDeliveryResults[].sender.senderKey         | String              | 발신 프로필 발신 키, 알림톡과 친구톡만 표시                                                         |
+| contactDeliveryResults[].sender.senderProfileId   | String              | 발신 프로필 아이디, 알림톡과 친구톡만 표시                                                          |
+| contactDeliveryResults[].sender.senderProfileType | String              | 발신 프로필 타입, 알림톡과 친구톡만 표시                                                           |
+| contactDeliveryResults[].sender.senderPhoneNumber | String              | 발신자 전화번호, SMS만 표시                                                                 |
+| contactDeliveryResults[].sender.senderMailAddress | String              | 발신자 이메일 주소, 이메일만 표시                                                               |
+| contactDeliveryResults[].sender.brandId           | String              | 브랜드 아이디, RCS만 표시                                                                  |
+| contactDeliveryResults[].sender.chatbotId         | String              | 대화방 아이디, RCS만 표시                                                                  |
+| contactDeliveryResults[].templateId               | String              | 템플릿의 아이디, 템플릿 메시지만 표시                                                             |
+| contactDeliveryResults[].flowId                   | String              | 플로우의 아이디, 템플릿 메시지만 표시                                                             |
+| contactDeliveryResults[].statsKeyId               | String              | 통계 키의 아이디                                                                         |
+| contactDeliveryResults[].messageChannel           | String              | 메시지 채널<br>SMS, RCS, ALIMTALK, FRIENDTALK, EMAIL, PUSH                             |
+| contactDeliveryResults[].messagePurpose           | String              | 메시지 목적                                                                            |
+| contactDeliveryResults[].confirmBeforeSend        | Boolean             | 승인 후 발송 사용 여부                                                                     |
+| contactDeliveryResults[].confirmedDateTime        | DateTime(ISO 86091) | 승인 일시(예: 2024-10-29T06:09:00+09:00)                                               |
+| contactDeliveryResults[].scheduled                | Boolean             | 예약 발송 여부                                                                          |
+| contactDeliveryResults[].scheduledDateTime        | DateTime(ISO 86091) | 예약 발송 일시                                                                          |
+| contactDeliveryResults[].status                   | String              | 상태<br> 요청 취소(CANCELED), 발송 실패(SEND_FAILED), 수신(DELIVERED), 수신 실패(DELIVERY_FAILED) |
+| contactDeliveryResults[].resultCode               | String              | 결과 코드                                                                             |
+| contactDeliveryResults[].resultMessage            | String              | 결과 메시지                                                                            |
+| contactDeliveryResults[].templateParameters       | Object              | 템플릿 파라미터                                                                          |
+| contactDeliveryResults[].additionalProperty       | Object              | 추가 속성, 알림톡, RCS만 제공                                                               |
+| contactDeliveryResults[].createdDateTime          | DateTime(ISO 86091) | 요청 일시(예: 2024-10-29T06:09:00+09:00)                                               |
+| contactDeliveryResults[].sentDateTime             | DateTime(ISO 86091) | 발송 일시, 발송 이벤트가 수집되기 전까지 값은 null                                                   |
+| contactDeliveryResults[].deliveredDateTime        | DateTime(ISO 86091) | 수신 일시, 수신 이벤트가 수집되기 전까지 값은 null                                                   |
+| contactDeliveryResults[].openedDateTime           | DateTime(ISO 86091) | 열람 일시, 열람 이벤트가 수집되기 전까지 값은 null, 푸시와 이메일만 제공                                      |
+| contactDeliveryResults[].updatedDateTime          | DateTime(ISO 86091) | 마지막 업데이트 일시                                                                       |
+| totalCount                                        | Number              | 전체 개수                                                                             |
 
 
 
@@ -367,7 +346,7 @@ X-NHN-Authorization: Bearer {accessToken}
   <summary><strong>IntelliJ HTTP</strong></summary>
 
 ```http
-POST {{endpoint}}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={결과 업데이트 일시 시작 범위}&updatedDateTimeTo={결과 업데이트 일시 종료 범위}&limit=10&offset=0
+POST {{endpoint}}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={업데이트 일시 시작 범위}&updatedDateTimeTo={업데이트 일시 종료 범위}&limit=10&offset=0
 Content-Type: application/json
 X-NC-APP-KEY: {{appKey}}
 X-NHN-Authorization: {{authorizationToken}}
@@ -379,7 +358,7 @@ X-NHN-Authorization: {{authorizationToken}}
   <summary><strong>cURL</strong></summary>
 
 ```curl
-curl -X GET "${ENDPOINT}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={결과 업데이트 일시 시작 범위}&updatedDateTimeTo={결과 업데이트 일시 종료 범위}&limit=10&offset=0" \
+curl -X GET "${ENDPOINT}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={업데이트 일시 시작 범위}&updatedDateTimeTo={업데이트 일시 종료 범위}&limit=10&offset=0" \
      -H "Content-Type: application/json" \
      -H "X-NC-APP-KEY: ${APP_KEY}" \
      -H "X-NHN-Authorization: ${ACCESS_TOKEN}"

--- a/ko/api-guide-v1x0/contact-delivery-result.md
+++ b/ko/api-guide-v1x0/contact-delivery-result.md
@@ -174,7 +174,7 @@ X-NHN-Authorization: Bearer {accessToken}
 GET {{endpoint}}/message/v1.0/contact-delivery-results?createdDateTimeFrom={요청 일시 시작 범위}&createdDateTimeTo={요청 일시 종료 범위}&limit=10&offset=0
 Content-Type: application/json
 X-NC-APP-KEY: {{appKey}}
-X-NHN-Authorization: {{authorizationToken}}
+X-NHN-Authorization: Bearer {{authorizationToken}}
 ```
 
 </details>
@@ -186,7 +186,7 @@ X-NHN-Authorization: {{authorizationToken}}
 curl -X GET "${ENDPOINT}/message/v1.0/contact-delivery-results?createdDateTimeFrom={요청 일시 시작 범위}&createdDateTimeTo={요청 일시 종료 범위}&limit=10&offset=0" \
      -H "Content-Type: application/json" \
      -H "X-NC-APP-KEY: ${APP_KEY}" \
-     -H "X-NHN-Authorization: ${ACCESS_TOKEN}"
+     -H "X-NHN-Authorization: Bearer ${ACCESS_TOKEN}"
 ```
 
 </details>
@@ -349,7 +349,7 @@ X-NHN-Authorization: Bearer {accessToken}
 POST {{endpoint}}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={업데이트 일시 시작 범위}&updatedDateTimeTo={업데이트 일시 종료 범위}&limit=10&offset=0
 Content-Type: application/json
 X-NC-APP-KEY: {{appKey}}
-X-NHN-Authorization: {{authorizationToken}}
+X-NHN-Authorization: Bearer {{authorizationToken}}
 ```
 
 </details>
@@ -361,7 +361,7 @@ X-NHN-Authorization: {{authorizationToken}}
 curl -X GET "${ENDPOINT}/message/v1.0/final-contact-delivery-results?updatedDateTimeFrom={업데이트 일시 시작 범위}&updatedDateTimeTo={업데이트 일시 종료 범위}&limit=10&offset=0" \
      -H "Content-Type: application/json" \
      -H "X-NC-APP-KEY: ${APP_KEY}" \
-     -H "X-NHN-Authorization: ${ACCESS_TOKEN}"
+     -H "X-NHN-Authorization: Bearer ${ACCESS_TOKEN}"
 ```
 
 </details>


### PR DESCRIPTION
# 설명
새로 추가되는 `최종 발송 결과 목록 조회 API` 가이드를 추가합니다.

기존 `연락처별 수신 결과 목록 조회`와 응답 형상은 완벽하게 동일합니다.

다른점은 다음과 같습니다.
- 조회시 시간 범위가 `createdDateTimeFrom/To` 대신 `updatedDateTimeFrom/To`
- 검색 필터로 `status`가 없음
- 최종 상태(CANCELED, SEND_FAILED, DELIVERED, DELIVERY_FAILED)인 발송건만 조회됨

# markdown 형태로 미리보기 (실제 가이드와 다를 수 있음)
![image](https://github.com/user-attachments/assets/6710afcd-4dd3-4d61-be95-740344fc671f)
![image](https://github.com/user-attachments/assets/e80499f5-c51a-4323-9993-e565c6012476)
![image](https://github.com/user-attachments/assets/ad6f8fd1-5434-48f1-a568-7da4d1afe27b)
![image](https://github.com/user-attachments/assets/c41963d3-7c3c-457d-be7c-08641aa5968c)
